### PR TITLE
Fix edge case: disappearing target 

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -138,7 +138,7 @@ function TooltipController(options) {
 		// only hook these listeners if we're not in manual mode.
 		//
 		// It's possible there won't be a display controller available to the
-		// even handlers. This will happen for example if activeHover has been
+		// event handlers. This will happen for example if activeHover has been
 		// removed from the DOM with $.remove, which strips the elements data.
 		// If that's the case, nothing has to be done, the tip will be closed
 		// by the desync handler.

--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -132,23 +132,35 @@ function TooltipController(options) {
 			}
 		});
 
-		// if we want to be able to mouse on to the tooltip then we need to
+		// If we want to be able to mouse on to the tooltip then we need to
 		// attach hover events to the tooltip that will cancel a close request
 		// on mouseenter and start a new close request on mouseleave
-		// only hook these listeners if we're not in manual mode
+		// only hook these listeners if we're not in manual mode.
+		//
+		// It's possible there won't be a display controller available to the
+		// even handlers. This will happen for example if activeHover has been
+		// removed from the DOM with $.remove, which strips the elements data.
+		// If that's the case, nothing has to be done, the tip will be closed
+		// by the desync handler.
 		if (options.mouseOnToPopup && !options.manual) {
 			tipElement.on('mouseenter' + EVENT_NAMESPACE, function tipMouseEnter() {
 				// check activeHover in case the mouse cursor entered the
 				// tooltip during the fadeOut and close cycle
 				if (session.activeHover) {
-					session.activeHover.data(DATA_DISPLAYCONTROLLER).cancel();
+					var displayController = session.activeHover.data(DATA_DISPLAYCONTROLLER);
+					if (displayController) {
+						displayController.cancel();
+					}
 				}
 			});
 			tipElement.on('mouseleave' + EVENT_NAMESPACE, function tipMouseLeave() {
 				// check activeHover in case the mouse cursor left the tooltip
 				// during the fadeOut and close cycle
 				if (session.activeHover) {
-					session.activeHover.data(DATA_DISPLAYCONTROLLER).hide();
+					var displayController = session.activeHover.data(DATA_DISPLAYCONTROLLER);
+					if (displayController) {
+						displayController.hide();
+					}
 				}
 			});
 		}
@@ -379,7 +391,11 @@ function TooltipController(options) {
 				// for tooltips opened via the api: we need to check if it has
 				// the forcedOpen flag.
 				if (!isMouseOver(session.activeHover) && !session.activeHover.is(':focus') && !session.activeHover.data(DATA_FORCEDOPEN)) {
-					if (tipElement.data(DATA_MOUSEONTOTIP)) {
+					if (tipElement.data(DATA_MOUSEONTOTIP) ||
+						// check if the activeHover still has a display
+						// controller, which it wouldn't e.g. if it was removed
+						// from the DOM using jQuery's remove method
+						!session.activeHover.data(DATA_DISPLAYCONTROLLER)) {
 						if (!isMouseOver(tipElement)) {
 							isDesynced = true;
 						}

--- a/test/edge-cases.html
+++ b/test/edge-cases.html
@@ -96,6 +96,11 @@
 		<p>The button below will disable itself 2 seconds after you hover or focus on it. The tooltip should close.</p>
 		<input type="button" value="Hover over me" title="This is the tooltip text." />
 	</section>
+	<section id="disappearing-button">
+		<h2>Disappearing button</h2>
+		<p>The button below will toggle a tooltip when clicked. When the mouse is moved over the tooltip, the button will disappear, then the tooltip will be closed. PowerTip should not encounter an error when this happens.</p>
+		<input type="button" value="Click me" title="Mouse over this tooltip text." />
+	</section>
 	<section id="long-delay">
 		<h2>Long delay</h2>
 		<p>The two buttons below have tooltips with long delays. Mousing from one to the other should open tooltips normally.</p>

--- a/test/tests-edge.js
+++ b/test/tests-edge.js
@@ -54,7 +54,7 @@ $(function() {
 				.one('mouseenter.disappearingButton', function() {
 					$btn.remove();
 				})
-				.one('mouseleave.disapperingButton', function() {
+				.one('mouseleave.disappearingButton', function() {
 					$btn.appendTo('#disappearing-button');
 					// recreate tooltip text and powertip and event handler
 					$btn.on('click', disappearingClickHandler);

--- a/test/tests-edge.js
+++ b/test/tests-edge.js
@@ -35,6 +35,34 @@ $(function() {
 	});
 	$('#auto-disable-button input').powerTip({ placement: 'e' });
 
+	// Disappearing button
+	var disappearingButtonOpts = {
+		openEvents: [ 'click' ],
+		placement: 'e',
+		mouseOnToPopup: true
+	};
+
+	$('#disappearing-button input')
+		.powerTip(disappearingButtonOpts)
+		.on('click', function disappearingClickHandler() {
+			var $btn = $(this),
+				content = $btn.data(DATA_POWERTIP);
+
+			// hook up mouse events to popup - remove on mouse enter, add back
+			// in when mouse leaves
+			$('#' + $.fn.powerTip.defaults.popupId)
+				.one('mouseenter.disappearingButton', function() {
+					$btn.remove();
+				})
+				.one('mouseleave.disapperingButton', function() {
+					$btn.appendTo('#disappearing-button');
+					// recreate tooltip text and powertip and event handler
+					$btn.on('click', disappearingClickHandler);
+					$btn.data(DATA_POWERTIP, content);
+					$btn.powerTip(disappearingButtonOpts);
+				});
+		});
+
 	// Long delay tooltips
 	$('#long-delay #first-button').powerTip({ closeDelay: 2000, mouseOnToPopup: true });
 	$('#long-delay #second-button').powerTip({ closeDelay: 2000 });

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -254,6 +254,86 @@ $(function() {
 		strictEqual(session.currentX, 1, 'document event removed');
 	});
 
+	test('API destroy method will not fail when rapidly created, shown, and destroyed', function() {
+		// run PowerTip
+		var element = $('<a href="#" title="This is the tooltip text"></a>')
+			.powerTip()
+			.on({
+				powerTipClose: function() {
+					$(this).powerTip('destroy');
+				}
+			});
+
+		// this bug happens when powerTip is initialized on top of an existing
+		// powerTip, shown, hidden, and destroyed all in the same breath.
+		element.powerTip()
+			.powerTip('show')
+			.powerTip('hide');
+
+		ok(true, 'PowerTip re-created, shown, hidden, and destroyed without error');
+
+		// try to recreate and reopen a new powerTip
+		stop();
+		setTimeout(function showAgain() {
+			var showCalled = false;
+			element.powerTip()
+				.data(
+					DATA_DISPLAYCONTROLLER,
+					new MockDisplayController(
+						function() {
+							showCalled = true;
+						}
+					)
+				);
+			element.powerTip('show');
+			ok(showCalled, 'PowerTip recreated and show was called without error');
+			start();
+		}, 20);
+
+	});
+
+	test('PowerTip will handle disappearing targets gracefully (mouseenter)', function() {
+		var opts = { fadeInTime: 0, mouseOnToPopup: true },
+			element = $('<a title="This is the tooltip text"></a>').powerTip({ mouseOnToPopup: true }),
+			tipElem = $('#' + $.fn.powerTip.defaults.popupId);
+		// show tip
+		element.powerTip('show');
+
+		// put mouse over tooltip
+		stop();
+		setTimeout(function() {
+			start();
+			tipElem.trigger('mouseenter');
+		}, 10);
+
+		// remove element from page
+		element.remove();
+
+		ok(true, 'PowerTip handled its target disappearing before mouseenter gracefully');
+	});
+
+	test('PowerTip will handle disappearing targets gracefully (mouseleave)', function() {
+		var opts = { fadeInTime: 0, mouseOnToPopup: true },
+			element = $('<a title="This is the tooltip text"></a>').powerTip(opts),
+			tipElem = $('#' + $.fn.powerTip.defaults.popupId);
+
+		// show tip
+		element
+			.on('powerTipOpen', function() {
+				tipElem.trigger('mouseenter');
+			})
+			.powerTip('show');
+
+		// remove element from page
+		element.remove();
+
+		tipElem.trigger('mouseleave');
+
+		// now do the same, but make the error happen on mouseleave
+
+		ok(true, 'PowerTip handled its target disappearing before mouseleave gracefully');
+	});
+
 	function MockDisplayController(show, hide, cancel, resetPosition) {
 		this.show = show || $.noop;
 		this.hide = hide || $.noop;

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -254,44 +254,6 @@ $(function() {
 		strictEqual(session.currentX, 1, 'document event removed');
 	});
 
-	test('API destroy method will not fail when rapidly created, shown, and destroyed', function() {
-		// run PowerTip
-		var element = $('<a href="#" title="This is the tooltip text"></a>')
-			.powerTip()
-			.on({
-				powerTipClose: function() {
-					$(this).powerTip('destroy');
-				}
-			});
-
-		// this bug happens when powerTip is initialized on top of an existing
-		// powerTip, shown, hidden, and destroyed all in the same breath.
-		element.powerTip()
-			.powerTip('show')
-			.powerTip('hide');
-
-		ok(true, 'PowerTip re-created, shown, hidden, and destroyed without error');
-
-		// try to recreate and reopen a new powerTip
-		stop();
-		setTimeout(function showAgain() {
-			var showCalled = false;
-			element.powerTip()
-				.data(
-					DATA_DISPLAYCONTROLLER,
-					new MockDisplayController(
-						function() {
-							showCalled = true;
-						}
-					)
-				);
-			element.powerTip('show');
-			ok(showCalled, 'PowerTip recreated and show was called without error');
-			start();
-		}, 20);
-
-	});
-
 	test('PowerTip will handle disappearing targets gracefully (mouseenter)', function() {
 		var opts = { fadeInTime: 0, mouseOnToPopup: true },
 			element = $('<a title="This is the tooltip text"></a>').powerTip({ mouseOnToPopup: true }),
@@ -328,8 +290,6 @@ $(function() {
 		element.remove();
 
 		tipElem.trigger('mouseleave');
-
-		// now do the same, but make the error happen on mouseleave
 
 		ok(true, 'PowerTip handled its target disappearing before mouseleave gracefully');
 	});


### PR DESCRIPTION
**Scenario**
`options.mouseOnToPopup` is set and the mouse is moved on top of the tooltip. Then the `session.activeHover` element is removed from the DOM using `$(session.activeHover).remove()` or similar which strips the element of its data.

**Problem**
The `mouseenter` and `mouseleave` handlers on the tooltip assume the existence of a `displayController` in `session.activeHover`'s data. 

**Solution**
Do nothing in the handlers if `displayController` is missing, and make sure that `closeDesyncedTip` will clean the tip up at some point.

I also added an example of this in `edge-cases.html` 
