### PR TITLE
Fix edge case: rapid re-init and destroy

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -338,7 +338,14 @@ $.powerTip = {
 			$window.off(EVENT_NAMESPACE);
 			$document.off(EVENT_NAMESPACE);
 			session.mouseTrackingActive = false;
-			session.tooltips.remove();
+			// It's possible in rare circumstances that the tooltip is already
+			// null here - if powerTip is reinstantiated, then shown and hidden
+			// in the same loop, and the `powerTipClose` event is handled by
+			// a function that calls destroy. In this case there is never a
+			// tooltip created anyway, so nothing has to be done to clean up.
+			if (session.tooltips) {
+				session.tooltips.remove();
+			}
 			session.tooltips = null;
 		}
 

--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -191,8 +191,10 @@ function TooltipController(options) {
 		session.desyncTimeout = clearInterval(session.desyncTimeout);
 
 		// reset element state
-		element.data(DATA_HASACTIVEHOVER, false);
-		element.data(DATA_FORCEDOPEN, false);
+		if (element) {
+			element.data(DATA_HASACTIVEHOVER, false);
+			element.data(DATA_FORCEDOPEN, false);
+		}
 
 		// remove document click handler
 		$document.off('click' + EVENT_NAMESPACE);
@@ -217,7 +219,9 @@ function TooltipController(options) {
 			tipElement.css(coords);
 
 			// trigger powerTipClose event
-			element.trigger('powerTipClose');
+			if (element) {
+				element.trigger('powerTipClose');
+			}
 		});
 	}
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -304,13 +304,25 @@ $(function() {
 				}
 			});
 
+		strictEqual(session.tooltips.length, 1, 'PowerTip tooltip element created');
+
 		// this bug happens when powerTip is initialized on top of an existing
 		// powerTip, shown, hidden, and destroyed all in the same breath.
 		element.powerTip()
 			.powerTip('show')
 			.powerTip('hide');
 
+		// placeholder message to show on script error
 		ok(true, 'PowerTip re-created, shown, hidden, and destroyed without error');
+
+		// check that elements were really destroyed
+		strictEqual(session.tooltips, null, 'PowerTip tooltip removed internally');
+		strictEqual($('#' + $.fn.powerTip.defaults.popupId).length, 0, 'tooltip element removed');
+
+		// check that events have been unhooked
+		session.currentX = 1;
+		$(document).trigger($.Event('mousemove', { pageX: 2, pageY: 3 }));
+		strictEqual(session.currentX, 1, 'document event removed');
 
 		// try to recreate and reopen a new powerTip
 		stop();

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -294,6 +294,44 @@ $(function() {
 		ok(true, 'PowerTip handled its target disappearing before mouseleave gracefully');
 	});
 
+	test('API destroy method will not fail when rapidly created, shown, and destroyed', function() {
+		// run PowerTip
+		var element = $('<a href="#" title="This is the tooltip text"></a>')
+			.powerTip()
+			.on({
+				powerTipClose: function() {
+					$(this).powerTip('destroy');
+				}
+			});
+
+		// this bug happens when powerTip is initialized on top of an existing
+		// powerTip, shown, hidden, and destroyed all in the same breath.
+		element.powerTip()
+			.powerTip('show')
+			.powerTip('hide');
+
+		ok(true, 'PowerTip re-created, shown, hidden, and destroyed without error');
+
+		// try to recreate and reopen a new powerTip
+		stop();
+		setTimeout(function showAgain() {
+			var showCalled = false;
+			element.powerTip()
+				.data(
+					DATA_DISPLAYCONTROLLER,
+					new MockDisplayController(
+						function() {
+							showCalled = true;
+						}
+					)
+				);
+			element.powerTip('show');
+			ok(showCalled, 'PowerTip recreated and show was called without error');
+			start();
+		}, 20);
+
+	});
+
 	function MockDisplayController(show, hide, cancel, resetPosition) {
 		this.show = show || $.noop;
 		this.hide = hide || $.noop;

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -256,7 +256,7 @@ $(function() {
 
 	test('PowerTip will handle disappearing targets gracefully (mouseenter)', function() {
 		var opts = { fadeInTime: 0, mouseOnToPopup: true },
-			element = $('<a title="This is the tooltip text"></a>').powerTip({ mouseOnToPopup: true }),
+			element = $('<a title="This is the tooltip text"></a>').powerTip(opts),
 			tipElem = $('#' + $.fn.powerTip.defaults.popupId);
 		// show tip
 		element.powerTip('show');
@@ -295,6 +295,8 @@ $(function() {
 	});
 
 	test('API destroy method will not fail when rapidly created, shown, and destroyed', function() {
+		expect(6);
+
 		// run PowerTip
 		var element = $('<a href="#" title="This is the tooltip text"></a>')
 			.powerTip()
@@ -341,7 +343,6 @@ $(function() {
 			ok(showCalled, 'PowerTip recreated and show was called without error');
 			start();
 		}, 20);
-
 	});
 
 	function MockDisplayController(show, hide, cancel, resetPosition) {


### PR DESCRIPTION
**Scenario**
`powerTip` is instantiated on an element that already has a `powerTip`, there is only one tooltip on the page, and `destroy` is called on that tooltip before it has a chance to show fully.

**Problem**
`session.tooltips` is `null` when `$.powerTip.destroy` tries to call `remove` on it.

**Solution**
Don't call `remove` when `session.tooltips` is `null`. Don't need to do anything there, since clearly there's nothing left to clean up.

There might be more stuff to fix if `powerTip` is instantiated multiple times on the same element, but this is the only issue I've seen with it.
