### PR TITLE
Edge case: multiple instantiations

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -85,6 +85,18 @@ $.fn.powerTip = function(opts, arg) {
 		return $.powerTip[opts].call(targetElements, targetElements, arg);
 	}
 
+	// Handle repeated powerTip calls on the same element by destroying the
+	// original instance hooked to it and replacing it with this call.
+	// Do this first to make sure 1) the tooltip element is not inadvertently
+	// removed, and 2) the target elements get reset correctly before the data
+	// elements are read.
+	targetElements.each(function destroyPreviousInstance() {
+		var $this = $(this);
+		if ($this.data(DATA_DISPLAYCONTROLLER)) {
+			$.powerTip.destroy($this);
+		}
+	});
+
 	// extend options and instantiate TooltipController
 	options = $.extend({}, $.fn.powerTip.defaults, opts);
 	tipController = new TooltipController(options);
@@ -99,12 +111,6 @@ $.fn.powerTip = function(opts, arg) {
 			dataElem = $this.data(DATA_POWERTIPJQ),
 			dataTarget = $this.data(DATA_POWERTIPTARGET),
 			title;
-
-		// handle repeated powerTip calls on the same element by destroying the
-		// original instance hooked to it and replacing it with this call
-		if ($this.data(DATA_DISPLAYCONTROLLER)) {
-			$.powerTip.destroy($this);
-		}
 
 		// attempt to use title attribute text if there is no data-powertip,
 		// data-powertipjq or data-powertiptarget. If we do use the title

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -36,6 +36,7 @@
 		"strictEqual": false,
 		"notStrictEqual": false,
 		"start": false,
+		"stop": false,
 
 		"DATA_DISPLAYCONTROLLER": false,
 		"DATA_HASACTIVEHOVER": false,

--- a/test/tests-edge.js
+++ b/test/tests-edge.js
@@ -1,6 +1,27 @@
 $(function() {
 	'use strict';
 
+	var hugeText = [
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent sed',
+		'volutpat tellus. Fusce mollis iaculis est at sodales. Proin aliquam',
+		'bibendum neque, nec blandit orci porttitor non. Cras lacinia varius',
+		'felis vel ultricies. Nulla eu sapien arcu, dapibus tempor eros.',
+		'Praesent aliquet hendrerit commodo. Pellentesque habitant morbi',
+		'tristique senectus et netus et malesuada fames ac turpis egestas.',
+		'Proin gravida justo faucibus urna dictum id egestas velit hendrerit.',
+		'Praesent dapibus rutrum tempor. Sed ultrices varius purus, eu rhoncus',
+		'tortor scelerisque sit amet. Sed vitae molestie diam. Pellentesque',
+		'posuere euismod venenatis. Proin ut ligula vel urna lacinia accumsan.',
+		'Quisque commodo ultrices orci ut cursus. Aliquam in dolor orci. Nunc',
+		'pretium euismod odio.'
+	].join(' '),
+		disappearingButtonOpts = {
+			openEvents: [ 'click' ],
+			placement: 'e',
+			mouseOnToPopup: true
+		};
+
+
 	// Open on load
 	$('#open-on-load input').powerTip({ placement: 'ne' }).powerTip('show');
 
@@ -36,12 +57,6 @@ $(function() {
 	$('#auto-disable-button input').powerTip({ placement: 'e' });
 
 	// Disappearing button
-	var disappearingButtonOpts = {
-		openEvents: [ 'click' ],
-		placement: 'e',
-		mouseOnToPopup: true
-	};
-
 	$('#disappearing-button input')
 		.powerTip(disappearingButtonOpts)
 		.on('click', function disappearingClickHandler() {
@@ -74,20 +89,6 @@ $(function() {
 	$('#manual-and-interactive #interactive-button').powerTip({ mouseOnToPopup: true });
 
 	// setup huge text tooltips
-	var hugeText = [
-		'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent sed',
-		'volutpat tellus. Fusce mollis iaculis est at sodales. Proin aliquam',
-		'bibendum neque, nec blandit orci porttitor non. Cras lacinia varius',
-		'felis vel ultricies. Nulla eu sapien arcu, dapibus tempor eros.',
-		'Praesent aliquet hendrerit commodo. Pellentesque habitant morbi',
-		'tristique senectus et netus et malesuada fames ac turpis egestas.',
-		'Proin gravida justo faucibus urna dictum id egestas velit hendrerit.',
-		'Praesent dapibus rutrum tempor. Sed ultrices varius purus, eu rhoncus',
-		'tortor scelerisque sit amet. Sed vitae molestie diam. Pellentesque',
-		'posuere euismod venenatis. Proin ut ligula vel urna lacinia accumsan.',
-		'Quisque commodo ultrices orci ut cursus. Aliquam in dolor orci. Nunc',
-		'pretium euismod odio.'
-	].join(' ');
 	$.each(
 		[
 			'north',


### PR DESCRIPTION
@nrabinowitz

This was an issue with the order things were getting called in the constructor, which I was a little worried about yesterday when I was working on #3. PowerTip had a reasonable idea of destroying the previous instance when it's recreated, but it wasn't doing it in the right place:
- Since `destroy` has the potential to remove the tooltip, it can't be called after `TooltipController`, which is where tooltips are created if necessary, is instantiated.
- Since `destroy` resets elements (resets their title attribute if possible and clears data attributes used by PT), this has to be done before the constructor sets itself up - otherwise it will have both a `data-powertip` attribute and a `title` attribute and an `data-originalTitle` attribute ... in other words, things are a mess.

Right now I'm using two loops through the elements, one to destroy, then one to recreate. This is the simplest way, it can be optimized ... I think it makes sense to fix this when the `$.add` stuff is taken care of, since that will also need to be put into this loop (to prevent inadvertent tooltip destruction).

I also fixed some lingering jshint and test lack-of-teardown issues from #2 and #3. Now the build passes, which is nice ...
