### PR TITLE
Adding a guard for null activeHover | WEB-4080

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -376,15 +376,25 @@ function TooltipController(options) {
 	 */
 	function closeDesyncedTip() {
 		var isDesynced = false;
+		var activeHover = session.activeHover;
 		// It is possible for the mouse cursor to leave an element without
 		// firing the mouseleave or blur event. This most commonly happens when
 		// the element is disabled under mouse cursor. If this happens it will
 		// result in a desynced tooltip because the tooltip was never asked to
 		// close. So we should periodically check for a desync situation and
 		// close the tip if such a situation arises.
-		if (session.isTipOpen && !session.isClosing && !session.delayInProgress && ($.inArray('mouseleave', options.closeEvents) > -1 || $.inArray('mouseout', options.closeEvents) > -1 || $.inArray('blur', options.closeEvents) > -1 || $.inArray('focusout', options.closeEvents) > -1)) {
+		if (activeHover &&
+			session.isTipOpen &&
+			!session.isClosing &&
+			!session.delayInProgress &&
+			($.inArray('mouseleave', options.closeEvents) > -1 ||
+				$.inArray('mouseout', options.closeEvents) > -1 ||
+				$.inArray('blur', options.closeEvents) > -1 ||
+				$.inArray('focusout', options.closeEvents) > -1
+			)) {
+
 			// user moused onto another tip or active hover is disabled
-			if (session.activeHover.data(DATA_HASACTIVEHOVER) === false || session.activeHover.is(':disabled')) {
+			if (activeHover.data(DATA_HASACTIVEHOVER) === false || activeHover.is(':disabled')) {
 				isDesynced = true;
 			} else {
 				// hanging tip - have to test if mouse position is not over the
@@ -394,12 +404,13 @@ function TooltipController(options) {
 				// not have focus.
 				// for tooltips opened via the api: we need to check if it has
 				// the forcedOpen flag.
-				if (!isMouseOver(session.activeHover) && !session.activeHover.is(':focus') && !session.activeHover.data(DATA_FORCEDOPEN)) {
+				if (!isMouseOver(activeHover) && !activeHover.is(':focus') && !activeHover.data(DATA_FORCEDOPEN)) {
 					if (tipElement.data(DATA_MOUSEONTOTIP) ||
 						// check if the activeHover still has a display
 						// controller, which it wouldn't e.g. if it was removed
 						// from the DOM using jQuery's remove method
-						!session.activeHover.data(DATA_DISPLAYCONTROLLER)) {
+						!activeHover.data(DATA_DISPLAYCONTROLLER)) {
+
 						if (!isMouseOver(tipElement)) {
 							isDesynced = true;
 						}
@@ -411,7 +422,7 @@ function TooltipController(options) {
 
 			if (isDesynced) {
 				// close the desynced tip
-				hideTip(session.activeHover);
+				hideTip(activeHover);
 			}
 		}
 	}


### PR DESCRIPTION
@jnu for review

This is a bit blind, in that all I know is that we got a stacktrace from production pointing to a particular line and column with the error `TypeError: Cannot read property 'data' of null`. But given that the line was in `closeDesyncedTip` and seemed to clearly indicate that `activeHover` was null here, and given that as far as I can tell the correct action in this case is nothing, I think simply adding the extra guard here is a reasonable precaution.
